### PR TITLE
refactor: apply basic python best practices

### DIFF
--- a/reminder.py
+++ b/reminder.py
@@ -4,14 +4,12 @@ import ctypes
 MB_SETFOREGROUND = 0x00010000
 MBeep = 0x00000000
 
-print("How many sets you want to perform?")
-amount = input()
-print("How many minutes you want to rest between the sets?")
-minutes = float(input())
-print("Do your first Set, you will be remembered for the next " + str(amount) + " sets")
+amount = input("How many sets you want to perform? ")
+minutes = float(input("How many minutes you want to rest between the sets? "))
+print(f"Do your first Set, you will be remembered for the next {amount} sets")
 
 for x in range(0, int(amount)):
-    local_time = float(minutes*60)
+    local_time = float(minutes * 60)
     time.sleep(local_time)
     MessageBeep = ctypes.windll.user32.MessageBeep(MBeep)
     MessageBox = ctypes.windll.user32.MessageBoxW


### PR DESCRIPTION
- you can pass a string to `input()`, so no need to use a `print()` (nice side effect: both are on the same line)
- use f-strings (or format if Python < 3.6) instead of string concatenation
- add white spaces around mathematical operations